### PR TITLE
Adding facebook.net to csp whitelist

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+	<policies>
+		<policy id="script-src">
+			<values>
+				<value id="fbpixel" type="host">*.facebook.net</value>
+			</values>
+		</policy>
+	</policies>
+</csp_whitelist>


### PR DESCRIPTION
Adding facebook.net to csp whitelist so pixel works when  Content Security Policies is enabled