### PR TITLE
Added Facebook eventID (order ID) for purchase event for deduplication when running a redundant set up

### DIFF
--- a/Block/Success.php
+++ b/Block/Success.php
@@ -70,6 +70,11 @@ class Success extends AbstractPixel
         return $product;
     }
 
+    public function getOrderId(): string
+    {
+        return $this->getCurrentQuote()->getRealOrderId();
+    }
+
     /**
      * @return Order
      */

--- a/view/frontend/templates/actions/success.phtml
+++ b/view/frontend/templates/actions/success.phtml
@@ -7,7 +7,8 @@
         "Magestat_FacebookPixel/js/actions/success": {
             "currency": "<?= /* @noEscape */ $block->getCurrencyCode() ?>",
             "contents": <?= /* @noEscape */ $block->getCartContent() ?>,
-            "total": "<?= /* @noEscape */ $block->getCheckoutTotal() ?>"
+            "total": "<?= /* @noEscape */ $block->getCheckoutTotal() ?>",
+            "orderId": "<?= $block->escapeJs($block->getOrderId()) ?>"
         }
     }
 }

--- a/view/frontend/templates/actions/success.phtml
+++ b/view/frontend/templates/actions/success.phtml
@@ -7,7 +7,6 @@
         "Magestat_FacebookPixel/js/actions/success": {
             "currency": "<?= /* @noEscape */ $block->getCurrencyCode() ?>",
             "contents": <?= /* @noEscape */ $block->getCartContent() ?>,
-            "contentIds": <?= /* @noEscape */ $block->getSkuList() ?>,
             "total": "<?= /* @noEscape */ $block->getCheckoutTotal() ?>"
         }
     }

--- a/view/frontend/web/js/actions/success.js
+++ b/view/frontend/web/js/actions/success.js
@@ -23,6 +23,6 @@ define([
             content_type: 'product',
             currency: data.currency,
             contents: data.contents,
-        });
+        }, {eventID: data.orderId});
     };
 });


### PR DESCRIPTION
Also see https://developers.facebook.com/docs/marketing-api/conversions-api/deduplicate-pixel-and-server-events